### PR TITLE
Fixes sample plugin file

### DIFF
--- a/Podfile_sample
+++ b/Podfile_sample
@@ -26,7 +26,6 @@ pod 'cordova-plugin-inappbrowser'
 pod 'cordova-plugin-file-transfer'
 pod 'cordova-plugin-statusbar'
 pod 'cordova-plugin-vibration'
-pod 'cordova-plugin-wkwebview-engine'
 
 # The following includes the PhoneGap iOS Platform Project Template for a quick start
 pod 'phonegap-ios-template'


### PR DESCRIPTION
The documentation [here](https://github.com/phonegap/phonegap-docs/blob/master/docs/2-tutorials/2-develop/1-embed-webview/1-ios.html.md) links to this sample file.  However this sample file is invalid and does not match the sample podfile embedded inline in that doc.  

The reason this sample file is invalid because `cordova-plugin-wkwebview-engine` requires ios 9 as a minimum target platform and this file specifies ios8.  According to the link above this pod isn't required at all.
